### PR TITLE
Merge sysmem changes

### DIFF
--- a/rusty-plants/Cargo.lock
+++ b/rusty-plants/Cargo.lock
@@ -1555,7 +1555,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -2378,6 +2378,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -4029,6 +4038,7 @@ dependencies = [
  "prisma-client-rust-cli",
  "rayon",
  "serde",
+ "sysinfo",
 ]
 
 [[package]]
@@ -4270,6 +4280,20 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4115055da5f572fff541dd0c4e61b0262977f453cc9fe04be83aba25a89bdab"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
 ]
 
 [[package]]
@@ -5070,10 +5094,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.5",
 ]

--- a/rusty-plants/Cargo.lock
+++ b/rusty-plants/Cargo.lock
@@ -1820,7 +1820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]

--- a/rusty-plants/Cargo.toml
+++ b/rusty-plants/Cargo.toml
@@ -12,5 +12,6 @@ directories = "5.0.1"
 human-panic = "2.0.0"
 rayon = "1.10.0"
 serde = { version = "1.0.198", features = ["derive"] }
+sysinfo = "0.31.2"
 prisma-client-rust = { git = "https://github.com/Brendonovich/prisma-client-rust", tag = "0.6.11" }
 prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust", tag = "0.6.11" }

--- a/rusty-plants/src/algorithms/read_align.rs
+++ b/rusty-plants/src/algorithms/read_align.rs
@@ -4,7 +4,7 @@ use crate::{
     file_io::fasta::Fragment,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Match {
     pub index: usize,
     pub errors: usize,

--- a/rusty-plants/src/algorithms/read_align.rs
+++ b/rusty-plants/src/algorithms/read_align.rs
@@ -4,7 +4,7 @@ use crate::{
     file_io::fasta::Fragment,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Match {
     pub index: usize,
     pub errors: usize,
@@ -40,6 +40,7 @@ pub fn align_fragment(
     }
     matches
 }
+
 
 // pub fn align_fragments(
 //     frags: &Vec<Fragment>,

--- a/rusty-plants/src/lib.rs
+++ b/rusty-plants/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod algorithms;
 pub mod data_structures;
 pub mod file_io;
+pub mod utils;

--- a/rusty-plants/src/main.rs
+++ b/rusty-plants/src/main.rs
@@ -8,7 +8,7 @@ use smarty_plants::{
         transcriptome::Transcriptome,
     },
     file_io::fasta::*,
-    utils::mem_usage::get_safe_memory_limit,
+    utils::mem_usage::{get_safe_memory_limit, process_chunk},
 };
 use std::{
     fs::{self, read_to_string},
@@ -26,21 +26,6 @@ struct Cli {
     genome_path: PathBuf,
 }
 
-fn process_chunk(transcriptome: &Transcriptome, st: &mut SuffixTree, start: usize, end: usize) {
-    for (i, c) in transcriptome
-        .get_bases()
-        .chars()
-        .map(|x| x as u8)
-        .skip(start)
-        .take(end - start)
-        .enumerate()
-    {
-        if (start + i) % 1_000_000 == 0 {
-            println!("Added up to transcriptome character {} to suffix tree", start + i);
-        }
-        st.extend(c);
-    }
-}
 
 fn main() {
     prisma_client_rust_cli::run();
@@ -51,33 +36,42 @@ fn main() {
     let read_dir = std::path::Path::new("../data/reads/");
     let files = read_directory_to_string(read_dir).expect("failed to read fragment files");
     let fragments = parse_file(&files).expect("failed to parse fragments");
-    let genome =
-        parse_genome(read_to_string("../data/ref_genome.fna").expect("failed to read genome file"));
+    let genome = parse_genome(read_to_string("../data/ref_genome.fna").expect("failed to read genome file"));
     let transcriptome = Transcriptome::new(&genome);
-    let mut st = suffix_tree::SuffixTree::new();
 
-    let max_chars = (safe_memory_limit * 1024) / std::mem::size_of::<u8>() as u64;
-
+    // Calculate max_chars and total_bases
+    let max_chars = (safe_memory_limit * 1024) / (std::mem::size_of::<u8>() as u64) / 2; // Reduce chunk size
     let total_bases = transcriptome.get_bases().chars().count();
     let num_chunks = (total_bases as f64 / max_chars as f64).ceil() as usize;
 
-
     for chunk in 0..num_chunks {
+        let mut st = SuffixTree::new();
         let start = chunk * max_chars as usize;
         let end = ((chunk + 1) * max_chars as usize).min(total_bases);
+
+        println!("Processing chunk from {} to {}", start, end);
         process_chunk(&transcriptome, &mut st, start, end);
 
-        st = suffix_tree::SuffixTree::new();
-    }
+        let sys = sysinfo::System::new_all();
+        println!("Memory usage after processing chunk {}: {} KB", chunk, sys.used_memory());
 
-    for i in 0..fragments.len() {
-        let matches = align_fragment(&fragments[i], &st, &transcriptome);
-        let mut best: &Match = &matches[0];
-        for m in matches.iter() {
-            if m.errors < best.errors {
-                best = &m;
+        println!("Aligning fragments");
+        for i in 0..fragments.len() {
+            let matches = align_fragment(&fragments[i], &st, &transcriptome);
+            let mut best: &Match = &matches[0];
+            for m in matches.iter() {
+                if m.errors < best.errors {
+                    best = &m;
+                }
             }
+            println!("{:?}, read_length: {}", best, &fragments[i].bases().len());
         }
-        println!("{:?}, read_length: {}", best, &fragments[i].bases().len());
+
+        drop(st);
+        std::thread::sleep(std::time::Duration::from_secs(10));
+
+        let sys = sysinfo::System::new_all();
+        println!("Memory after dropping suffix tree: {} KB", sys.used_memory());
     }
 }
+

--- a/rusty-plants/src/main.rs
+++ b/rusty-plants/src/main.rs
@@ -12,7 +12,9 @@ use smarty_plants::{
 use std::{
     fs::{self, read_to_string},
     path::PathBuf,
+    fs::File,
 };
+use std::io::{BufWriter, Write};
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -23,37 +25,70 @@ struct Cli {
     genome_path: PathBuf,
 }
 
+fn process_chunk(
+    chunk: &str,
+    fragments: &[Fragment],
+    transcriptome: &Transcriptome,
+) -> Vec<Match> {
+    let mut st = SuffixTree::new();
+    for c in chunk.chars().map(|x| x as u8) {
+        st.extend(c);
+    }
+
+    let mut best_matches = Vec::new();
+
+    for fragment in fragments {
+        let matches = align_fragment(fragment, &st, &transcriptome);
+        if let Some(best_match) = matches.iter().min_by_key(|m| m.errors) {
+            best_matches.push(best_match.clone());
+        }
+    }
+
+    best_matches
+}
+
+fn save_matches_to_file(matches: &[Match], filename: &str) {
+    let file = File::create(filename).expect("Unable to create file");
+    let mut writer = BufWriter::new(file);
+
+    for m in matches {
+        writeln!(
+            writer,
+            "Index: {}, Errors: {}",
+            m.index, m.errors
+        ).expect("Unable to write data to file");
+    }
+}
+
 fn main() {
     prisma_client_rust_cli::run();
 
     let read_dir = std::path::Path::new("../data/reads/");
     let files = read_directory_to_string(read_dir).expect("failed to read fragment files");
     let fragments = parse_file(&files).expect("failed to parse fragments");
-    let genome =
-        parse_genome(read_to_string("../data/ref_genome.fna").expect("failed to read genome file"));
+    let genome = parse_genome(read_to_string("../data/ref_genome.fna").expect("failed to read genome file"));
     let transcriptome = Transcriptome::new(&genome);
-    let mut st = suffix_tree::SuffixTree::new();
-    for (i, c) in transcriptome
-        .get_bases()
-        .chars()
-        .map(|x| x as u8)
-        .take(80_000_000)
-        .enumerate()
-    {
-        if i % 1_000_000 == 0 {
-            println!("Added up to transcriptome character {} to suffix tree", i);
-        }
-        st.extend(c);
+    
+    let chunk_size = 2_000_000;
+    let genome_length = transcriptome.get_bases().len();
+    let mut all_best_matches = Vec::new();
+
+    for chunk_start in (0..std::cmp::min(80_000_000, genome_length)).step_by(chunk_size) {
+        let chunk_end = std::cmp::min(chunk_start + chunk_size, genome_length);
+        let chunk = &transcriptome.get_bases()[chunk_start..chunk_end];
+
+        let best_matches = process_chunk(chunk, &fragments, &transcriptome);
+        all_best_matches.extend(best_matches);
+
+        // Save the current chunk results to a file
+        let filename = format!("chunk_{}_{}.txt", chunk_start, chunk_end);
+        save_matches_to_file(&all_best_matches, &filename);
+
+        // Clear memory by dropping the current chunk's results
+        all_best_matches.clear();
+
+        println!("Processed and saved chunk {} - {}", chunk_start, chunk_end);
     }
 
-    for i in 0..fragments.len() {
-        let matches = align_fragment(&fragments[i], &st, &transcriptome);
-        let mut best: &Match = &matches[0];
-        for m in matches.iter() {
-            if m.errors < best.errors {
-                best = &m;
-            }
-        }
-        println!("{:?}, read_length: {}", best, &fragments[i].bases().len());
-    }
+    println!("All chunks processed.");
 }

--- a/rusty-plants/src/utils/mem_usage.rs
+++ b/rusty-plants/src/utils/mem_usage.rs
@@ -14,20 +14,3 @@ pub fn get_safe_memory_limit() -> u64 {
 
 }
 
-pub fn process_chunk(transcriptome: &Transcriptome, st: &mut SuffixTree, start: usize, end: usize) {
-    for (i, c) in transcriptome
-        .get_bases()
-        .chars()
-        .map(|x| x as u8)
-        .skip(start)
-        .take(end - start)
-        .enumerate()
-    {
-        if (start + i) % 1_000_000 == 0 {
-            println!("Added up to transcriptome character {} to suffix tree", start + i);
-        }
-        st.extend(c);
-    }
-
-    println!("Finished processing chunk from {} to {}", start, end);
-}

--- a/rusty-plants/src/utils/mem_usage.rs
+++ b/rusty-plants/src/utils/mem_usage.rs
@@ -1,0 +1,33 @@
+use sysinfo::{System};
+use crate::data_structures::transcriptome::Transcriptome;
+use crate::data_structures::suffix_tree::SuffixTree;
+
+pub fn get_safe_memory_limit() -> u64 {
+    let sys = System::new_all();
+    let total_memory = sys.total_memory();
+    let used_memory = sys.used_memory();
+    let free_memory = total_memory - used_memory;
+
+    // Use 80% of the available memory as a safe threshold
+    let safe_memory_limit = (free_memory as f64 * 0.8) as u64;
+    safe_memory_limit
+
+}
+
+pub fn process_chunk(transcriptome: &Transcriptome, st: &mut SuffixTree, start: usize, end: usize) {
+    for (i, c) in transcriptome
+        .get_bases()
+        .chars()
+        .map(|x| x as u8)
+        .skip(start)
+        .take(end - start)
+        .enumerate()
+    {
+        if (start + i) % 1_000_000 == 0 {
+            println!("Added up to transcriptome character {} to suffix tree", start + i);
+        }
+        st.extend(c);
+    }
+
+    println!("Finished processing chunk from {} to {}", start, end);
+}

--- a/rusty-plants/src/utils/mod.rs
+++ b/rusty-plants/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod mem_usage;


### PR DESCRIPTION
Added system memory capability with @Mozes721 @AbyssalRemark 's work.
The utils and general-purpose functionality, and how to use them to `println!` a low memory message, and a graceful exit, can be moved into the `read_align.rs` binary.

The code changes also include a forest of smaller suffix trees that each cover different chunks or fragments of the entire genome. We'll move these into an alternative cargo binary, called something like "fragments.rs".

Then this change is ready to merge into `main`. The above are guidelines, up to the style of the implementor.